### PR TITLE
fix broken documentation link in README

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,7 @@
 Chess is a set of Go packages containing chess and chess960 related
 functionality.
 
-Documentation at GoPkgDoc:
-http://gopkgdoc.appspot.com/pkg/github.com/malbrecht/chess
+Documentation: https://godoc.org/github.com/malbrecht/chess
 
 Installation:
 


### PR DESCRIPTION
It seems gopkgdoc.appspot.com is dead; godoc.org is the modern equivalent. Thanks!
